### PR TITLE
Certificate sync: fix webserver port, update doco, fix timezones.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,18 @@ Prerequisites/Requirements:
 
 >!!! **All servers in the cluster will be sent the same certificate** It's common to use a single certificate for all servers in a CPPM cluster, with the fqdn of the Cluster VIP as the CN, and the FQDNs of each individual server/alias in the SAN.  The script will get a list of all of the Servers in the cluster, and verify/update the https certificate on each of them using the same certificate (specified in the config).
 
+API Client Permissions:
+
+- API Services -> Custom
+  - Allow API Access -> Allow Access
+- Platform -> Read Only Access
+- Policy Manager -> Custom
+  - Certificates -> Read, Write, Delete
+  - External Servers - Endpoint Context Servers -> Read
+  - Platform - Cluster Wide Parameters -> Read
+  - Platform - Servers -> Read
+
+
 Working Example (this is how it's done in my lab):
 
 - pfSense handles certificate renewals for all hosts in my lab (via acme package available in package manager).

--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ ssh -t wade@omv "clearpass-api-scripts/venv/bin/python3 clearpass-api-scripts/cp
 You can see from the comments in the script above how the flow works.
 
 > One key note, to ssh from pfSense to my NAS.  Certificate Authentication is in use, so no password has to be sent, which allows the remote command to run from this script without prompt.
-The PushBullet Notification is redundant in the case of ClearPass, but I have other certificates that also use this same script.  That piece is obviously optional.
+
+>The PushBullet Notification is redundant in the case of ClearPass, but I have other certificates that also use this same script.  That piece is obviously optional.
 
 You can also run this script manually: `./cppm-certsync.py`
 

--- a/README.md
+++ b/README.md
@@ -137,11 +137,11 @@ ssh -t wade@omv "clearpass-api-scripts/venv/bin/python3 clearpass-api-scripts/cp
 ```
 
 You can see from the comments in the script above how the flow works.
+
 > One key note, to ssh from pfSense to my NAS.  Certificate Authentication is in use, so no password has to be sent, which allows the remote command to run from this script without prompt.
 The PushBullet Notification is redundant in the case of ClearPass, but I have other certificates that also use this same script.  That piece is obviously optional.
 
-You can also run this script manually:
-`./cppm-certsync.py`
+You can also run this script manually: `./cppm-certsync.py`
 
 ------
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
 
 > Development is generally done in Ubuntu, scripts should work on other environments, but not necessarily tested.
 
----
+------
 
 A collection (of 2 currently) of Aruba ClearPass API Scripts
 
 Visit [the official Aruba GitHub](https://github.com/aruba/) for additional tools from the Aruba Automation Team.
 
----
+------
 
 ## Setup
 
@@ -50,13 +50,13 @@ Then use nano or your editor of preference to populate values in config.yaml (i.
 
 These scripts interact with the ClearPass API, so an API client needs to be configured for the scripts to use in the ClearPass Guest interface.
 
-> The `in`, `out`, and `log` directories are ignored by git. The scripts will look for any input files in the `in` directory, will send any generated reports/output to `out` and will log to the `log` directory.
+>The `in`, `out`, and `log` directories are ignored by git.  The scripts will look for any input files in the `in` directory, will send any generated reports/output to `out` and will log to the `log` directory.
 
----
+------
 
 ## Current Tools
 
----
+------
 
 ### Certificate Sync
 
@@ -64,7 +64,7 @@ This Script is used to Update ClearPass' https certificate with one from a provi
 
 #### Setup:
 
-Complete the [common setup](#setup), and ensure required entries are populated in `config.yaml`. You can copy or use `config.yaml.example` as a reference.
+Complete the [common setup](#setup), and ensure required entries are populated in `config.yaml`.  You can copy or use `config.yaml.example` as a reference.
 
 #### Example Flow:
 
@@ -72,7 +72,7 @@ Complete the [common setup](#setup), and ensure required entries are populated i
 - You run this script either by triggering it from the tool used to do the auto-renewal or periodically via CRON or the like (or manually).
 - cppm-certsync will compare the expiration of the certificate on each server in the CPPM cluster to the certificate specified in the config and available to the script in the Filesystem.
 - If the new cert has an expiration beyond that of the cert currently in CPPM, the script will start a webserver, then send an API request to CPPM instructing it to download/import the new cert and use as it's https certificate.
-- If an update occurred, or was attempted, but resulted in an error a notification can be sent (via PushBullet). If no update was required, no notification is sent.
+- If an update occurred, or was attempted, but resulted in an error a notification can be sent (via PushBullet).  If no update was required, no notification is sent.
 
 #### Prerequisites/Requirements:
 
@@ -80,9 +80,9 @@ Complete the [common setup](#setup), and ensure required entries are populated i
 - The root/signing cert needs to be imported/enabled in the Trusted Certs in ClearPass (as with any https cert you would import).
   - Clearpass Policy Manager -> Administration -> Certificates -> Trust List
 - The Auto-Renewal with LetsEncrypt or the like is handled by a different tool, the certificate needs to be available to whatever host runs cppm-synccerts (i.e. a mounted NAS drive).
-- ClearPass is instructed to import the certificate via the API, it does so by reaching out to a web-server and downloading the file. This script starts a webserver which by default listens on port 8080 (cofnigurable), so that port would need to be available and allowed on the host this script runs on.
+- ClearPass is instructed to import the certificate via the API, it does so by reaching out to a web-server and downloading the file.  This script starts a webserver which by default listens on port 8080 (cofnigurable), so that port would need to be available and allowed on the host this script runs on.
 
-> !!! **All servers in the cluster will be sent the same certificate** It's common to use a single certificate for all servers in a CPPM cluster, with the fqdn of the Cluster VIP as the CN, and the FQDNs of each individual server/alias in the SAN. The script will get a list of all of the Servers in the cluster, and verify/update the https certificate on each of them using the same certificate (specified in the config).
+>!!! **All servers in the cluster will be sent the same certificate** It's common to use a single certificate for all servers in a CPPM cluster, with the fqdn of the Cluster VIP as the CN, and the FQDNs of each individual server/alias in the SAN.  The script will get a list of all of the Servers in the cluster, and verify/update the https certificate on each of them using the same certificate (specified in the config).
 
 #### API Client Permissions:
 
@@ -137,14 +137,13 @@ ssh -t wade@omv "clearpass-api-scripts/venv/bin/python3 clearpass-api-scripts/cp
 ```
 
 You can see from the comments in the script above how the flow works.
-
-> One key note, to ssh from pfSense to my NAS. Certificate Authentication is in use, so no password has to be sent, which allows the remote command to run from this script without prompt.
-> The PushBullet Notification is redundant in the case of ClearPass, but I have other certificates that also use this same script. That piece is obviously optional.
+> One key note, to ssh from pfSense to my NAS.  Certificate Authentication is in use, so no password has to be sent, which allows the remote command to run from this script without prompt.
+The PushBullet Notification is redundant in the case of ClearPass, but I have other certificates that also use this same script.  That piece is obviously optional.
 
 You can also run this script manually:
 `./cppm-certsync.py`
 
----
+------
 
 ### xml-import-builder
 
@@ -156,7 +155,7 @@ This script was built to aid in role/role-mapping/and enforcement-policy creatio
 
 Customer had an export that included 2 pertinent columns of data: AD Group and Cisco ASA/EasyConnect VPN Tunnel they were authorized to access based on that AD Group.
 
-The export was converted to csv and cleaned, up. Header line was stripped out (the script doesn't try to detect the header).
+The export was converted to csv and cleaned, up.  Header line was stripped out (the script doesn't try to detect the header).
 
 **Roles and Role Mapping are created with the following rules:**
 
@@ -165,10 +164,10 @@ The export was converted to csv and cleaned, up. Header line was stripped out (t
 
 Enforcement Policy is created with rules:
 
-- if Tips Role = _assigned from role mapping_ then Allow Access Profile (send Radius Accept.)
+- if Tips Role = *assigned from role mapping* then Allow Access Profile (send Radius Accept.)
 
 **USAGE:**
-You can specify `in_file` in the CPPM section of the configuration, or as the first argument when running the script. Command line argument will be honored and `in_file` in config will be ignored if both are populated.
+You can specify `in_file` in the CPPM section of the configuration, or as the first argument when running the script.  Command line argument will be honored and `in_file` in config will be ignored if both are populated.
 API access is still required as some queries are done to gather data to populate the xml import.
 
 > Note the script also has a function and logic to creat the roles and role-mapping via the Rest API, those are commented out, as xml was going to be required for the enforcement anyway.

--- a/cppm-certsync.py
+++ b/cppm-certsync.py
@@ -46,7 +46,7 @@ def get_timezone_from_abbr(abbr):
         # Using the timezone object, get the name of the timezone from datetime
         tz_name = now.astimezone(timezone).tzname()
         if tz_name == abbr:
-            return timezone
+            return timezone # Pendulum can handle a pytz timezone object, or a string
 
     return abbr  # Fallback to the original, pendulum might be able to handle it, who knows?
 

--- a/cppm-certsync.py
+++ b/cppm-certsync.py
@@ -41,13 +41,13 @@ pb_key = NOTIFY.get("api_key")
 def get_timezone_from_abbr(abbr):
     """Convert timezone abbreviation to a valid pytz timezone string."""
     now = datetime.datetime.now()
-    for tz in pytz.all_timezones:
-        timezone = pytz.timezone(tz)
-        try:
-            if now.astimezone(timezone).tzname() == abbr:
-                return tz
-        except Exception:
-            continue
+    for tz in pytz.all_timezones: # Iterate through all timzones list[str]
+        timezone = pytz.timezone(tz) # Create a timezone object
+        # Using the timezone object, get the name of the timezone from datetime
+        tz_name = now.astimezone(timezone).tzname()
+        if tz_name == abbr:
+            return timezone
+
     return abbr  # Fallback to the original, pendulum might be able to handle it, who knows?
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,10 @@ cache-dir = "~/.cache/ruff"
 target-version = "py312"
 line-length = 300 # Setting high to not reformat existing code
 
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 filterwarnings = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,11 @@ typer = ">=0.6"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.ruff]
+cache-dir = "~/.cache/ruff"
+target-version = "py312"
+line-length = 300 # Setting high to not reformat existing code
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 filterwarnings = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 aiohttp
 aiodns
 Brotli
+pytz
 cryptography>=42.0.7
 halo>=0.0.31
 Jinja2>=3.1.4


### PR DESCRIPTION
### README.md

- Add API client setup/permissions section
- Minor formatting changes

### Pyproject.toml

- Apologies but I instinctively press the key-combination to format my code with ruff. I set some settings to make it not reformat your code too much.

### Requirements.txt

- New dependency pytz (Bindings for the Olson tz database)

### cppm-certsync.py

- Fix http.server port
  - Previously it read from config, but never got used
  - get_webserver_url returns the port as well now
  - start_webserver is now called with the port defined
- Much better timezone recognition. New dependency pytz is used to handle (hopefully) any time zone abbreviation, as AWST was not supported. I will not complain about Americans
- Reformat, everything uses double quotes now, as it was the much more commonly used option in the file
  - Sorry