### PR TITLE
Support other certificates and make internal webserver optional

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -14,6 +14,7 @@ CPPM:
   https_cert_p12: cppm.arubalab.net.p12  # used as final portion of webserver full url, and as last part of local cert path
   https_cert_passphrase: reD@cted!!
   #svc: "HTTPS(RSA)"  # the ClearPass service: "RADIUS", "HTTPS(ECC)", "HTTPS(RSA)", "RadSec", "Database"
+  webserver_enable: true  # set to false to use an existing web server
   webserver:
     base_url: http://omv.arubalab.net  # ip or fqdn cppm would use to access server hosting the cert (this system or external)
     port: 8080

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -13,6 +13,7 @@ CPPM:
   client_secret: ClearPass-API-Client-Secret-Goes-Here
   https_cert_p12: cppm.arubalab.net.p12  # used as final portion of webserver full url, and as last part of local cert path
   https_cert_passphrase: reD@cted!!
+  #svc: "HTTPS(RSA)"  # the ClearPass service: "RADIUS", "HTTPS(ECC)", "HTTPS(RSA)", "RadSec", "Database"
   webserver:
     base_url: http://omv.arubalab.net  # ip or fqdn cppm would use to access server hosting the cert (this system or external)
     port: 8080

--- a/cppm-certsync.py
+++ b/cppm-certsync.py
@@ -172,7 +172,8 @@ def put_https_cert(
 ) -> list:
     """Update https Certificate to CPPM"""
 
-    svc = "HTTPS" if int(server_version[1]) < 10 else "HTTPS(RSA)"
+    https_svc = "HTTPS" if int(server_version[1]) < 10 else "HTTPS(RSA)"
+    svc = cppm_config.get("svc", https_svc)
     urls = [(svr, f"https://{cppm_fqdn}/api/server-cert/name/{uuid}/{svc}") for svr, uuid in servers.items()]
 
     payload = {


### PR DESCRIPTION
I'm using the script to upload both HTTPS and RADIUS certificates from a machine with an existing webserver, so I have added options to the config file to allow this.

The svc option specifies which certificate to upload - if not configured, it'll still default to HTTPS.

The webserver_enable option can be set to false to prevent the server from starting. If it's not set or set to true, the server will be started.

The get_system_ip() function is not called if the config file specifies the base URL, because this function can cause a fatal error if you have a complicated routing setup.