### PR TITLE
🔖 v2025-10.0 (cppm-certsync)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 - [ClearPass API Scripts](#clearpass-api-scripts)
   - [Setup](#setup)
   - [Current Tools](#current-tools)
-  - [Certificate Sync](#certificate-sync)
-  - [xml-import-builder](#xml-import-builder)
+    - [Certificate Sync](#certificate-sync)
+    - [xml-import-builder](#xml-import-builder)
 
 > Development is generally done in Ubuntu, scripts should work on other environments, but not necessarily tested.
 
@@ -12,16 +12,16 @@
 
 A collection (of 2 currently) of Aruba ClearPass API Scripts
 
-Visit [the official Aruba GitHub](https://github.com/aruba/) for additional tools from the Aruba Automation Team.
+🎉 Visit [the official Aruba GitHub](https://github.com/aruba/) for additional tools from the Aruba Automation Team.
 
 ------
 
 ## Setup
 
-Clone The Repo
+### Clone The Repo
 `git clone https://github.com/Pack3tL0ss/cppm-api-scripts.git`
 
-Setup the Virtual Environment
+### Setup the Virtual Environment
 
 ```bash
 export DEB_PYTHON_INSTALL_LAYOUT='deb'  # on POSIX / *NIX based system
@@ -52,11 +52,8 @@ These scripts interact with the ClearPass API, so an API client needs to be conf
 
 >The `in`, `out`, and `log` directories are ignored by git.  The scripts will look for any input files in the `in` directory, will send any generated reports/output to `out` and will log to the `log` directory.
 
-------
 
 ## Current Tools
-
-------
 
 ### Certificate Sync
 
@@ -70,7 +67,7 @@ Complete the [common setup](#setup), and ensure required entries are populated i
 
 - You use an existing solution/tool (not this script) to do automatic renewal with LetsEncrypt (or similar) provider.
 - You run this script either by triggering it from the tool used to do the auto-renewal or periodically via CRON or the like (or manually).
-- cppm-certsync will compare the expiration of the certificate on each server in the CPPM cluster to the certificate specified in the config and available to the script in the Filesystem.
+- `cppm-certsync` will compare the expiration of the certificate on each server in the CPPM cluster to the certificate specified in the config and available to the script in the Filesystem.
 - If the new cert has an expiration beyond that of the cert currently in CPPM, the script will start a webserver, then send an API request to CPPM instructing it to download/import the new cert and use as it's https certificate.
 - If an update occurred, or was attempted, but resulted in an error a notification can be sent (via PushBullet).  If no update was required, no notification is sent.
 
@@ -79,10 +76,11 @@ Complete the [common setup](#setup), and ensure required entries are populated i
 - An API Client Configured in ClearPass Guest Interface, and appropriate configuration in this scripts config.yaml
 - The root/signing cert needs to be imported/enabled in the Trusted Certs in ClearPass (as with any https cert you would import).
   - Clearpass Policy Manager -> Administration -> Certificates -> Trust List
-- The Auto-Renewal with LetsEncrypt or the like is handled by a different tool, the certificate needs to be available to whatever host runs cppm-synccerts (i.e. a mounted NAS drive).
-- ClearPass is instructed to import the certificate via the API, it does so by reaching out to a web-server and downloading the file.  This script starts a webserver which by default listens on port 8080 (cofnigurable), so that port would need to be available and allowed on the host this script runs on.
+- The Auto-Renewal with LetsEncrypt or the like is handled by a different tool, the certificate needs to be available to whatever host runs cppm-certsync (i.e. a mounted NAS drive). or available via a webserver on a different system.
+- ClearPass is instructed to import the certificate via the API, it does so by reaching out to a web-server and downloading the file.  By default this script starts a webserver termporarily so CPPM can download the certificate.  Alternatively the webserver can be a different host, it just needs to be accessible from both the host running this script and the ClearPass nodes.
+- If this host is running the webserver, the _(configurable)_ port it listens on needs to be available (not bound to another process).
 
->!!! **All servers in the cluster will be sent the same certificate** It's common to use a single certificate for all servers in a CPPM cluster, with the fqdn of the Cluster VIP as the CN, and the FQDNs of each individual server/alias in the SAN.  The script will get a list of all of the Servers in the cluster, and verify/update the https certificate on each of them using the same certificate (specified in the config).
+>!!! **All servers in the cluster will be sent the same certificate** It's common to use a single certificate for all servers in a CPPM cluster, with the fqdn of the Cluster VIP as the CN _(the same should also be repeated as a SAN entry)_, and the FQDNs of each individual server/alias in the SAN.  The script will get a list of all of the Servers in the cluster, and verify/update the https certificate on each of them using the same certificate (specified in the config).
 
 #### API Client Permissions:
 
@@ -140,9 +138,9 @@ You can see from the comments in the script above how the flow works.
 
 > One key note, to ssh from pfSense to my NAS.  Certificate Authentication is in use, so no password has to be sent, which allows the remote command to run from this script without prompt.
 
->The PushBullet Notification is redundant in the case of ClearPass, but I have other certificates that also use this same script.  That piece is obviously optional.
+> The PushBullet Notification is redundant in the case of ClearPass, but I have other certificates that also use this same script.  That piece is obviously optional.
 
-You can also run this script manually: `./cppm-certsync.py`
+You can also run this script manually: `./cppm-certsync.py`  _(Once you've activated the venv `source venv/bin/activate` Linux/Mac or `venv\Scripts\activate` Windows)_
 
 ------
 
@@ -172,3 +170,5 @@ You can specify `in_file` in the CPPM section of the configuration, or as the fi
 API access is still required as some queries are done to gather data to populate the xml import.
 
 > Note the script also has a function and logic to creat the roles and role-mapping via the Rest API, those are commented out, as xml was going to be required for the enforcement anyway.
+
+> ⚠ This script has not really been used or tested since the engagement it was built for.  If it's useful for something, but needs tweaks, create an issue with the details.

--- a/common/__init__.py
+++ b/common/__init__.py
@@ -90,7 +90,7 @@ class AosConnect(Response):
 class MyLogger:
     def __init__(self, log_file: str | Path, debug: bool = False, show: bool = False):
         self.log_msgs: List[str] = []
-        self.DEBUG = debug
+        self._DEBUG = debug
         self.verbose = False
         if isinstance(log_file, Path):
             self.log_file = log_file
@@ -99,6 +99,15 @@ class MyLogger:
         self._log = self.get_logger()
         self.name = self._log.name
         self.show = show  # Sets default log behavior (other than debug)
+
+    @property
+    def DEBUG(self):
+        return self._DEBUG
+
+    @DEBUG.setter
+    def DEBUG(self, value: bool):
+        self._log.setLevel(level=logging.DEBUG if value else logging.INFO)
+        self._DEBUG = value
 
     def get_logger(self):
         '''Return custom log object.'''
@@ -183,3 +192,32 @@ log_file = _calling_script.joinpath(_calling_script.resolve().parent, "logs", f"
 
 # config = Config()
 log = MyLogger(log_file, show=True)
+
+
+class Utils:  # class for the sake of namespace
+    @staticmethod
+    def exit(msg: str = None, code: int = 1, emoji: bool = True) -> None:
+        """Print msg text and exit.
+
+        Prepends warning emoji to msg if code indicates an error.
+            emoji arg has not impact on this behavior.
+            Nothing is displayed if msg is not provided.
+
+        Args:
+            msg (str, optional): The msg to display (supports rich markup). Defaults to None.
+            code (int, optional): The exit status. Defaults to 1 (indicating error).
+            emoji (bool, optional): Set to false to disable emoji. Defaults to True.
+
+        Raises:
+            builtin exit to exit program.
+        """
+        console = Console(emoji=emoji, stderr=code)
+        if code != 0:
+            msg = f"[dark_orange3]\u26a0[/]  {msg}" if msg else msg  # \u26a0 = ⚠ / :warning:
+
+        if msg:
+            console.print(msg)
+
+        exit(code=code)
+
+utils = Utils()

--- a/common/config.py
+++ b/common/config.py
@@ -1,18 +1,171 @@
 #!/usr/bin/env python3
 #
 # Author: Wade Wells github/Pack3tL0ss
+from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
 import yaml
+from yarl import URL
+import sys
+import netifaces
+import socket
+from rich.console import Console
+from functools import cached_property
+
+from typing import Dict, Literal
+
+NotifyService = Literal["pushbullet"]
+
+econsole = Console(stderr=True)
+
+class WebServer:
+    def __init__(self, base_url: str = None, port: int = None, path: str = None, local: bool = None, web_root: str | Path = None, cert_dir: str | Path = None):
+        web_root = web_root or cert_dir  # cert_dir is depricated
+        self.base_url: URL = base_url if not isinstance(base_url, str) else URL(base_url)
+        self._port = port
+        self._path = path
+        self._local: bool = local
+        self.web_root: Path = web_root if not web_root or isinstance(web_root, Path) else Path(web_root)
+
+    @cached_property
+    def url(self) -> URL | None:  # We allow this class to be instantiated with no values to avoid having to do multiple checks elsewhere
+        if not self.base_url:
+            return
+        port_str = "" if self.base_url and self.base_url == self.port else f":{self.port}"
+        return URL(f"{self.base_url}{port_str}/{self.path}")
+
+    @cached_property
+    def path(self) -> str:
+        return "" if not self._path else self._path.lstrip("/")
+
+    @cached_property
+    def port(self) -> int:
+        if self._port:
+            return int(self._port)
+        if not self.base_url:
+            return 8080
+
+        return self.base_url.port
+
+    @cached_property
+    def local(self) -> bool:
+        if not self.base_url:
+            return False
+
+        return self._this_is_server(self.base_url, self._local)
+
+    @property
+    def valid(self) -> bool:
+        return self.url is not None
+
+    @staticmethod
+    def _get_system_ip() -> str:
+        pub_ip = None
+        try:  # determine which IP is associated with the default gateway
+            gw = netifaces.gateways()
+            pub_iface = gw["default"][netifaces.AF_INET][1]
+            pub_iface_addr = netifaces.ifaddresses(pub_iface)
+            pub_ip = pub_iface_addr[netifaces.AF_INET][0]["addr"]
+        except Exception as e:
+            econsole.print(f"[bright_red]!![/]::warning:: Error Attempting to determine external IP: {e.__class__.__name__}")
+            econsole.print("You can set webserver: local: to True or False to bypass this check.")
+            # econsole.print(f"Exception in get_system_ip(): {e}")
+
+        return pub_ip
+
+    def _this_is_server(self, url: URL, local: bool | None = None) -> bool:
+        if isinstance(local, bool):
+            return local
+
+        my_ip = self._get_system_ip()
+
+        try:
+            if my_ip and socket.gethostbyname(url.host) not in ["127.0.0.1", "::1", my_ip]:
+                econsole.print(f"[dark_orange]:information:[/] webserver [cyan]{url.host}[/] defined in config does not appear to be this system.")
+                return False
+        except Exception as e:
+            econsole.print(f"{e.__class__.__name__} Exception in Config.WebServer._this_is_server()\n{e}")
+
+        return True
+
+class Certificate:
+    def __init__(self, p12: str, passphrase: str):
+        self.p12 = p12
+        self.passphrase = passphrase
+
+    def __iter__(self):
+        return iter(("p12", self.p12), ("passphrase", self.passphrase))
+
+class Notify:
+    def __init__(self, key: str, service: NotifyService = "pushbullet"):
+        self.name = self.service = service.lower()
+        self.key = key
 
 
 class Config:
     def __init__(self):
         BASE_DIR = Path(__file__).parent.parent
-        yaml_config = BASE_DIR.joinpath('config.yaml')
-        self.config = self.get_yaml_file(yaml_config) or {}
+        self.file: Path = BASE_DIR.joinpath('config.yaml')
+        self.config: Dict[str, Any] = self.get_yaml_file(self.file) or {}
         self.DEBUG = self.config.get("debug", False)
+        self.cppm_config: Dict[str, str | Dict[str, str]] = self.config.get("CPPM") or self.config.get("cppm", {})
+        self.fqdn = self.cppm_config.get("fqdn")
+        self.client_id = self.cppm_config.get("client_id")
+        self.client_secret = self.cppm_config.get("client_secret")
+        self.grant_type = self.cppm_config.get("grant_type", "client_credentials")
+        self.username = self.cppm_config.get("username")
+        self.password = self.cppm_config.get("password")
+        if "webserver" not in self.cppm_config:
+            self.webserver = None
+        else:
+            try:
+                if "cert_dir" in self.cppm_config and "web_root" not in self.cppm_config["webserver"]:  # allow cert_dir under CPPM as was the case in prev versions
+                    self.cppm_config["webserver"]["web_root"] = self.cppm_config["cert_dir"]
+                self.webserver = WebServer(**self.cppm_config["webserver"])
+            except TypeError as e:
+                print(str(e))
+                print("Config is missing required base_url under webserver")
+                self.webserver = None
+
+        self.certificates = self._get_certificates()
+
+    @property
+    def notify(self) -> Notify | None:
+        _notify_config: Dict[str, str] = self.config.get("NOTIFY") or self.config.get("notify")
+        if not _notify_config:
+            return
+        return Notify(_notify_config.get("api_key"), service=_notify_config.get("service"))
+
+    def _get_certificates(self) -> Dict[str, Dict[str, str]]:
+        if "certificates" in self.cppm_config:
+            certs: Dict[str, Dict[str, str]] = self.cppm_config["certificates"]
+            return {k: Certificate(**v) for k, v in certs.items()}
+        if "https_cert_p12" in self.cppm_config:
+            return {
+                "https_rsa": {
+                    "p12": self.cppm_config["https_cert_p12"],
+                    "passphrase": self.cppm_config.get("https_cert_passphrase")
+                }
+            }
+
+    @property
+    def valid(self) -> bool:
+        required = ["fqdn", "client_id", "client_secret"]
+        if self.grant_type == "password":
+            required += ["username", "password"]
+
+        return None not in [getattr(self, field) for field in required]
+
+    @property
+    def valid_cert_sync(self) -> bool:
+        if not self.valid:
+            return self.valid
+        conditions = [
+            self.webserver and self.webserver.base_url,
+            self.certificates
+        ]
+        return all(conditions)
 
     def __bool__(self):
         return len(self.config) > 0
@@ -31,4 +184,4 @@ class Config:
                 try:
                     return yaml.load(f, Loader=yaml.SafeLoader)
                 except ValueError as e:
-                    print(f'Unable to load configuration from {yaml_config}\n\t{e}')
+                    print(f'Unable to load configuration from {yaml_config}\n\t{e}', file=sys.stderr)

--- a/common/config.py
+++ b/common/config.py
@@ -137,16 +137,13 @@ class Config:
             return
         return Notify(_notify_config.get("api_key"), service=_notify_config.get("service"))
 
-    def _get_certificates(self) -> Dict[str, Dict[str, str]]:
+    def _get_certificates(self) -> Dict[str, Certificate]:
         if "certificates" in self.cppm_config:
             certs: Dict[str, Dict[str, str]] = self.cppm_config["certificates"]
             return {k: Certificate(**v) for k, v in certs.items()}
         if "https_cert_p12" in self.cppm_config:
             return {
-                "https_rsa": {
-                    "p12": self.cppm_config["https_cert_p12"],
-                    "passphrase": self.cppm_config.get("https_cert_passphrase")
-                }
+                "https_rsa": Certificate(p12=self.cppm_config["https_cert_p12"], passphrase=self.cppm_config.get("https_cert_passphrase"))
             }
 
     @property

--- a/common/cppmauth.py
+++ b/common/cppmauth.py
@@ -2,7 +2,6 @@
 
 import requests
 import sys
-# from common import config
 from functools import partial
 from typing import Literal, Dict, Any, Union
 from yarl import URL

--- a/common/cppmauth.py
+++ b/common/cppmauth.py
@@ -1,75 +1,65 @@
 #!/usr/bin/env python3
-# ------------------------------------------------------------------------------
-#
-# Author: @timcappalli, Aruba Security Group
-#
-# Modified By: Wade Wells Nov 2020
-# Based on v 2017.03
-#
-# Organization: Aruba, a Hewlett Packard Enterprise company
-#
-# Version: 2020-1.0
-#
-# Copyright (c) Hewlett Packard Enterprise Development LP
-# All Rights Reserved
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied. See the License for the
-# specific language governing permissions and limitations
-# under the License.
-#
-# ------------------------------------------------------------------------------
+
 import requests
-from common import config
+import sys
+# from common import config
+from functools import partial
+from typing import Literal, Dict, Any, Union
+from yarl import URL
+import pendulum
+from functools import wraps
+
+from .config import Config
+
+print = partial(print, file=sys.stderr)
+GrantType = Literal["client_credentials", "password"]
+StrOrURL = Union[str, URL]
+
+class ClearPassAuth(Config):
+    def __init__(self):
+        super().__init__()
+        self.oath_base_url = URL(f"https://{self.fqdn}/api/oauth")
+        self._token_response = self.get_access_token()
+        self.access_token = self._token_response['access_token']
+        self.token_type = self._token_response['token_type']
+        self.token_expires_in = pendulum.duration(seconds=self._token_response['expires_in'])
+        self.scope = self._token_response['scope']
 
 
-cppm_config = config.get("CPPM")
+    @property
+    def headers(self) -> Dict[str, str]:
+        _headers = {'Content-Type': 'application/json'}
+        if hasattr(self, "access_token"):
+            _headers = {**_headers, "Authorization": f"{self.token_type} {self.access_token}"}
 
-clearpass_fqdn = cppm_config.get('fqdn')
-oauth_grant_type = cppm_config.get('grant_type', "client_credentials")
-oauth_client_id = cppm_config.get('client_id')
-oauth_client_secret = cppm_config.get('client_secret')
-oauth_username = cppm_config.get('username')
-oauth_password = cppm_config.get('password')
+        return _headers
 
+    def build_url(func):
+        @wraps(func)
+        def wrapper(self, url: StrOrURL, *args, **kwargs):
+            url = url if url.startswith("http") else self.oath_base_url / url.lstrip("/")
+            return func(self, url, *args, **kwargs)
 
-# validate config
-def check_config(clearpass_fqdn, oauth_grant_type, oauth_client_id, oauth_client_secret, oauth_username, oauth_password):
-    """Validate the OAuth 2.0 configuration from the config.yaml file."""
+        return wrapper
 
-    if not clearpass_fqdn:
-        print(f'Error: ClearPass FQDN must be defined in config file ({config.yaml_config})')
-        exit(1)
-    if not oauth_grant_type:
-        print(f'Error: grant_type must be defined in config file ({config.yaml_config})')
-        exit(1)
-    if not oauth_client_id:
-        print(f'Error: client_id must be defined in config file ({config.yaml_config})')
-        exit(1)
-    if oauth_grant_type == "password" and (not oauth_username or not oauth_password):
-        print(f'Error: username and password must be defined in config file for password grant type ({config.yaml_config})')
-        exit(1)
+    @build_url
+    def get(self, url) -> Dict[str, Any]:
+        """Generic GET request"""
 
+        try:
+            r = requests.get(url, headers=self.headers)
+            r.raise_for_status()
+        except Exception as e:
+            print(e)
+            exit(1)
 
-def get_access_token(clearpass_fqdn, oauth_grant_type, oauth_client_id, oauth_client_secret, oauth_username, oauth_password):
-    """Get OAuth 2.0 access token with config from config.yaml"""
+        return r.json()
 
-    url = "https://" + clearpass_fqdn + "/api/oauth"
+    @build_url
+    def post(self, url: str, payload: Dict[str, Any] = None, headers: Dict[str, str] = None) -> Dict[str, Any]:
+        """Generic POST request"""
 
-    headers = {'Content-Type': 'application/json'}
-
-    # grant_type: password
-    if oauth_grant_type == "password":
-        payload = {'grant_type': oauth_grant_type, 'username': oauth_username, 'password': oauth_password,
-                   'client_id': oauth_client_id, 'client_secret': oauth_client_secret}
+        headers = headers or self.headers
 
         try:
             r = requests.post(url, headers=headers, json=payload)
@@ -80,79 +70,41 @@ def get_access_token(clearpass_fqdn, oauth_grant_type, oauth_client_id, oauth_cl
 
         return r.json()
 
-    # grant_type: password   public client
-    if oauth_grant_type == "password" and not oauth_client_secret:
-        payload = {'grant_type': oauth_grant_type, 'username': oauth_username,
-                   'password': oauth_password, 'client_id': oauth_client_id}
+    def get_access_token(self):
+        """Get OAuth 2.0 access token with config from config.yaml"""
 
-        try:
-            r = requests.post(url, headers=headers, json=payload)
-            r.raise_for_status()
-        except Exception as e:
-            print(e)
-            exit(1)
+        url = f"https://{self.fqdn}/api/oauth"
 
-        return r.json()
+        # headers = {'Content-Type': 'application/json'}
 
-    # grant_type: client_credentials
-    if oauth_grant_type == "client_credentials":
-        payload = {'grant_type': oauth_grant_type, 'client_id': oauth_client_id, 'client_secret': oauth_client_secret}
+        # grant_type: client_credentials
+        if self.grant_type == "client_credentials":
+            payload = {'grant_type': self.grant_type, 'client_id': self.client_id, 'client_secret': self.client_secret}
 
-        try:
-            r = requests.post(url, headers=headers, json=payload)
-            r.raise_for_status()
-        except Exception as e:
-            print(e)
-            exit(1)
+        # grant_type: password   public client
+        if self.grant_type == "password" and not self.client_secret:
+            payload = {'grant_type': self.grant_type, 'username': self.username,
+                    'password': self.password, 'client_id': self.client_id}
 
-        return r.json()
+        # grant_type: password
+        if self.grant_type == "password":
+            payload = {'grant_type': self.grant_type, 'username': self.username, 'password': self.password,
+                    'client_id': self.client_id, 'client_secret': self.client_secret}
 
+        return self.post(url, payload=payload)
 
-def get_api_role(clearpass_fqdn, token_type, access_token):
-    """Get the current ClearPass operator profile name"""
+    def get_api_role(self):
+        """Get the current ClearPass operator profile name"""
 
-    url = "https://" + clearpass_fqdn + "/api/oauth/me"
+        url = f"https://{self.fqdn}/api/oauth/me"
 
-    headers = {'Content-Type': 'application/json', "Authorization": "{} {}".format(token_type, access_token)}
+        res = self.get(url)
+        return res.get('info', res)
 
-    try:
-        r = requests.get(url, headers=headers)
-        r.raise_for_status()
-    except Exception as e:
-        print(e)
-        exit(1)
+    def get_privs(self):
+        """Get the current access privileges"""
 
-    return r.json()
+        url = f"https://{self.fqdn}/api/oauth/privileges"
 
-
-def get_privs(clearpass_fqdn, token_type, access_token):
-    """Get the current access privileges"""
-
-    url = "https://" + clearpass_fqdn + "/api/oauth/privileges"
-
-    headers = {'Content-Type': 'application/json', "Authorization": "{} {}".format(token_type, access_token)}
-
-    try:
-        r = requests.get(url, headers=headers)
-        r.raise_for_status()
-    except Exception as e:
-        print(e)
-        exit(1)
-
-    return r.json()
-
-
-check_config(clearpass_fqdn, oauth_grant_type, oauth_client_id, oauth_client_secret, oauth_username, oauth_password)
-
-token_response = get_access_token(clearpass_fqdn, oauth_grant_type, oauth_client_id,
-                                  oauth_client_secret, oauth_username, oauth_password)
-access_token = token_response['access_token']
-token_type = token_response['token_type']
-token_expires_in = token_response['expires_in']
-scope = token_response['scope']
-
-get_api_role_response = get_api_role(clearpass_fqdn, token_type, access_token)
-api_role = get_api_role_response['info']
-
-get_privs_response = get_privs(clearpass_fqdn, token_type, access_token)
-api_privs = get_privs_response['privileges']
+        res = self.get(url)
+        return res.get('privileges', res)

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -3,16 +3,29 @@
 
 # CPPM Defaults:
 # -- grant_type: client_credentials
-# -- webserver: port: 8080
+# -- webserver: port: Not included in url if not provided (so 80 if url is http or 443 if url is https)
 # -- username: nul (must provide value if grant_type: password)
 # -- password: nul (must provide value if grant_type: password)
-# -- FQDN can be VIP all servers in cluster will be sent cert
+# -- fqdn should be fqdn of VIP or publisher.  Cluster nodes will be querried and all nodes will have certs updated.
 CPPM:
   fqdn: cppm.arubalab.net
   client_id: Full API Client
   client_secret: ClearPass-API-Client-Secret-Goes-Here
-  https_cert_p12: cppm.arubalab.net.p12  # used as final portion of webserver full url, and as last part of local cert path
-  https_cert_passphrase: reD@cted!!
+
+  certificates:  # At least 1 certificate type is required.  By default the script will update all defined types unless called with one or more command line flags --https-rsa --https-ecc --radius --radsec
+    https_rsa:   # This represents the HTTPS(RSA) service in ClearPass > 6.10, or HTTPS in older versions
+      p12: https-rsa-cppm.arubalab.net.p12  # used as final portion of webserver full url, and as filename expected to exist in web_root (dir) if webserver is local
+      passphrase: reD@cted!!
+    #https_ecc:
+    #  p12: https-ecc-cppm.arubalab.net.p12
+    #  passphrase: reD@cted!!
+    #radius:
+    #  p12: radius-cppm.arubalab.net.p12
+    #  passphrase: reD@cted!!
+    #radsec:
+    #  p12: radsec-cppm.arubalab.net.p12
+    #  passphrase: reD@cted!!
+
   webserver:
     base_url: http://omv.arubalab.net  # ip or fqdn cppm would use to access server hosting the cert (this system or external)
     port: 8080
@@ -20,8 +33,8 @@ CPPM:
     local: false  # if not provided the script will attempt to determine if this is the server hosting the cert files.
                   # setting local will bypass the check.  local: true will result in webserver being started on this system
                   # to serve certificates to cppm.  If set to false the server at base_url should be providing the webserver.
-  # The above will result in "http://omv.arubalab.net:8080/certs/cppm.arubalab.net.p12" being used as the full path where CPPM can get the cert
-  cert_dir: "/export/FileDump/certificates/LetsEncrypt"
+    web_root: /export/FileDump/certificates/LetsEncrypt  # Only applies if this script is also going to act as a temporary webserver to host the certificate.
+    # The above will result in "http://omv.arubalab.net:8080/certs/https-rsa-cppm.arubalab.net.p12" being used as the full path where CPPM can get the https_rsa cert. The actual cert files should exist in the web_root directory.
 
   # -- // used in pol-elements-from-csv.py \\ --
   in_file: in/adgroup2tunnel.csv

--- a/cppm-certsync.py
+++ b/cppm-certsync.py
@@ -58,21 +58,11 @@ def _get_timezone_from_abbr(abbr) ->zoneinfo.ZoneInfo | str:
 
 
 class CpHandler(BaseHTTPRequestHandler):
-    passphrase: str = None
-    # CERTNAME: str = None
-    cert_p12: str = None
-
-    @classmethod
-    def init(cls, cert_p12: str, passphrase: str) -> None:
-        cls.cert_p12 = cert_p12
-        cls.passphrase = passphrase
-
     def do_GET(self):
-        install(show_locals=True)  # better Traceback hook
         self.send_response(200)
         self.send_header("Content-Type", "application/x-pkcs12")
         self.end_headers()
-        p = cppm.webserver.web_root / self.cert_p12
+        p = cppm.webserver.web_root / self.path.split("/")[-1]
         self.wfile.write(p.read_bytes())
         log.info(f"Sending {p.name}")
         return
@@ -153,10 +143,6 @@ def start_webserver(port: int = None) -> HTTPServer | None:
             log.warning(f"Something Appears to be Using port {port}")
         else:
             log.info(f"Starting WebServer on Port {port}")
-            # handler = CpHandler
-            # CpHandler.init(cert_p12=cert_p12, passphrase=cert_passphrase)
-            # handler.CERTNAME = cert_p12
-            # handler.passphrase = cert_passphrase
             httpd = HTTPServer(("", port), CpHandler)
             httpd.allow_reuse_address = True
             threading.Thread(target=httpd.serve_forever, args=[2], name="webserver").start()

--- a/cppm-certsync.py
+++ b/cppm-certsync.py
@@ -63,11 +63,11 @@ class CpHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         p = cppm.webserver.web_root / self.path.split("/")[-1]
         if p.exists():
-            log.info(f"Sending {p.name}")
-            self.wfile.write(p.read_bytes())
+            log.info(f"Sending {p.name} to {self.address_string()}")
             self.send_response(HTTPStatus.OK)
             self.send_header("Content-Type", "application/x-pkcs12")
             self.end_headers()
+            self.wfile.write(p.read_bytes())
         else:
             log.error(f"Unable to fulfill request from [cyan]{self.address_string()}[/] for [cyan]{p.name}[/].  [cyan]{p}[/] [red]File Not Found[/].")
             self.send_error(HTTPStatus.NOT_FOUND)

--- a/cppm-certsync.py
+++ b/cppm-certsync.py
@@ -264,7 +264,7 @@ def put_certs() -> List[Tuple[str, Service, UpdateRes]]:
                 else:
                     words = ('same', 'as') if diff.days == 0 else ('older', 'than')
                     _msg = f"New cert has {words[0]} expiration {words[1]} {req.name} {req.svc} cert. No Update performed."
-                    _res.append((req.name, req.svc, "word"))
+                    _res.append((req.name, req.svc, words[0]))
                     log.info(_msg)
             else:
                 _res.append((req.name, req.svc, "error"))
@@ -321,7 +321,7 @@ def do_push(res):
     if "no-push" not in str(sys.argv):
         push = _load_pb()
         try:
-            if push and [r[2] for r in res if r[2] != "same"]:
+            if push and [r[2] for r in res if r[2] not in ["same", "older"]]:
                 res_str = "\n".join([f"{svr} ({svc}): {result}" for svr, svc, result in res])
                 push_res = push("ClearPass Cert Update", res_str)
                 log.debug(f"Push Response:\n{push_res}")

--- a/cppm-certsync.py
+++ b/cppm-certsync.py
@@ -12,11 +12,11 @@ import sys
 import threading
 import zoneinfo
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from os import environ as env
-from pathlib import Path, PurePath
-from typing import Any, Dict, Tuple
+from pathlib import Path
+from typing import Any, Dict, List, TYPE_CHECKING, Literal, Tuple
+from functools import lru_cache
 
-import netifaces
+# import netifaces
 import pendulum
 import requests
 from cryptography.hazmat.backends import default_backend
@@ -24,23 +24,25 @@ from cryptography.hazmat.primitives.serialization import pkcs12
 from rich.console import Console
 from yarl import URL
 
-from common import cppmauth, log
+from common import log
+from common.cppmauth import ClearPassAuth
+if TYPE_CHECKING:
+    from common.config import Certificate
 
-cppm_config: Dict[str, Any] = cppmauth.config.get("CPPM", {})
 
-cppm_args = (cppmauth.clearpass_fqdn, cppmauth.token_type, cppmauth.access_token)
-cert_p12 = cppm_config.get("https_cert_p12")
-cert_passphrase = cppm_config.get("https_cert_passphrase")
-cert_dir = cppm_config.get("cert_dir")
+UpdateRes = Literal["updated", "same", "error"]
+Service = Literal["HTTPS", "HTTPS(RSA)", "RADIUS", "RadSec"]
 
-NOTIFY: Dict[str, str] = cppmauth.config.get("NOTIFY", {})
-pb_key = NOTIFY.get("api_key")
+
+console = Console()
+econsole = Console(stderr=True)
+cppm = ClearPassAuth()
 
 
 # certificate expiry looks like 'Apr 04, 2025 14:04:11 CDT'
-# but pendulum format specifier for timezone (zz) doesn't like some of the values "CDT, EDT..."
-# are not valid.  Below is used to get around this swapping for valid values from tz database
-def get_timezone_from_abbr(abbr) ->zoneinfo.ZoneInfo | str:
+# CDT is not valid IANA tz Identifier.  So we iterate through all valid TimeZones
+# and generate tzname names until we find a match, then return that ZoneInfo object
+def _get_timezone_from_abbr(abbr) ->zoneinfo.ZoneInfo | str:
     """Convert timezone abbreviation to a valid ZoneInfo timezone string."""
     now = datetime.datetime.now()
     for tz in zoneinfo.available_timezones():
@@ -54,51 +56,254 @@ def get_timezone_from_abbr(abbr) ->zoneinfo.ZoneInfo | str:
 
 
 class CpHandler(BaseHTTPRequestHandler):
-    CERTNAME: str = None
     passphrase: str = None
+    # CERTNAME: str = None
+    cert_p12: str = None
+
+    @classmethod
+    def init(cls, cert_p12: str, passphrase: str) -> None:
+        cls.cert_p12 = cert_p12
+        cls.passphrase = passphrase
 
     def do_GET(self):
         self.send_response(200)
         self.send_header("Content-Type", "application/x-pkcs12")
         self.end_headers()
-        p = Path(PurePath(cert_dir, cert_p12))
+        p = cppm.webserver.web_root / self.cert_p12
         self.wfile.write(p.read_bytes())
         log.info(f"Sending {p.name}")
         return
 
 
-def _get_system_ip() -> str:
-    pub_ip = None
-    try:  # determine which IP is associated with the default gateway
-        gw = netifaces.gateways()
-        pub_iface = gw["default"][netifaces.AF_INET][1]
-        pub_iface_addr = netifaces.ifaddresses(pub_iface)
-        pub_ip = pub_iface_addr[netifaces.AF_INET][0]["addr"]
+@lru_cache(typed=True)
+def get_le_cert_from_external(webserver_full_url: str):
+    try:
+        r = requests.get(webserver_full_url)
+        if not r.ok:
+            econsole.print(f"[dark_orange3]:warning:[/]  Failed to get cert from external webserver {webserver_full_url}")
+            exit(1)
+        else:
+            return r.content
     except Exception as e:
-        log.exception(f"Exception in get_system_ip(): {e}")
-        c = Console()
-        c.print(f"[bright_red]!![/]::warning:: Error Attempting to determine external IP: {e.__class__.__name__}")
-        c.print("You can set webserver: local: to True or False to bypass this check.")
+        log.exception(f"Exception occured while getting current LE cert from {webserver_full_url}. {e.__class__.__name__}", show=True)
+        log.exception(e)
+        exit(1)
 
-    return pub_ip
 
-def _this_is_server(full_url: URL) -> bool:
-    config_is_local = cppm_config.get("webserver", {}).get("local")
-    if isinstance(config_is_local, bool):
-        return config_is_local
-
-    my_ip = _get_system_ip()
+def get_cert_expiration(cert_p12: str, cert_passphrase: str, webserver_url: URL | str) -> datetime.datetime:
+    webserver_url: URL = webserver_url if isinstance(webserver_url, URL) else URL(webserver_url)
+    full_url = webserver_url / cert_p12
+    p, pb = None, None
+    if not cppm.webserver.local:
+        pb = get_le_cert_from_external(full_url)
+        log.debug(get_le_cert_from_external.cache_info())
+    else:
+        local_paths: List[Path] = [cppm.webserver.web_root or Path().home() / cert_p12, Path().cwd() / cert_p12]
+        for p in local_paths:
+            if p.exists():
+                pb = p.read_bytes()
+                break
+        if not pb:
+            log.fatal(f"{cert_p12} Not Found")
+            exit(1)
 
     try:
-        if my_ip and socket.gethostbyname(full_url.host) not in ["127.0.0.1", "::1", my_ip]:
-            return False
+        le_p12 = pkcs12.load_key_and_certificates(pb, cert_passphrase.encode("UTF-8"), backend=default_backend())
+        le_cert = le_p12[1]
+        le_exp = le_cert.not_valid_after_utc
     except Exception as e:
-        log.exception(f"{e.__class__.__name__} Exception in this_is_server()\n{e}")
+        _msg = f"[red]Exception[/]: [dim italic]({e.__class__.__name__}, {e})[/] in [cyan]get_cert_expiration[/]: During Attempt to get expiration from PKCS12 data.  Host: [magenta]{full_url.host}[/] Certificate: [cyan]{cert_p12}[/]."
+        if pb and "</html>" in str(pb):
+            _msg += f"  Response appears to be html not a PKCS12 certificate.  Perhaps the path ({full_url.path}) or port ({full_url.port}) is wrong."
+        _msg += "[red italic]Script will exit[/]."
+        log.error(_msg, show=True)
+        log.exception(e, show=False)
+        exit(1)
 
-    return True
+    return le_exp
 
-def load_pb():
-    if pb_key:
+
+def _get_server_ids() -> Dict[str, str]:
+    """Get list of server ids"""
+
+    url = f"https://{cppm.fqdn}/api/cluster/server"
+
+    headers = {"Content-Type": "application/json", "Authorization": f"{cppm.token_type} {cppm.access_token}"}
+
+    try:
+        r = requests.get(url, headers=headers)
+        r.raise_for_status()
+    except Exception as e:
+        log.error(f"exception: {e}")
+        exit(1)
+
+    servers: List[Dict[str, str]] = r.json().get("_embedded", {}).get("items", {})
+    return {svr.get("name"): svr.get("server_uuid") for svr in sorted(servers, key=lambda s: s["name"])}
+
+
+def start_webserver(port: int = None) -> HTTPServer | None:
+    port = port or cppm.webserver.port
+    def _start_webserver(port: int = None):
+        httpd = None
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        if s.connect_ex(("127.0.0.1", port)) == 0:
+            log.warning(f"Something Appears to be Using port {port}")
+        else:
+            log.info(f"Starting WebServer on Port {port}")
+            # handler = CpHandler
+            # handler.init(cert_p12=cert_p12, passphrase=cert_passphrase)
+            # handler.CERTNAME = cert_p12
+            # handler.passphrase = cert_passphrase
+            httpd = HTTPServer(("", port), CpHandler)
+            httpd.allow_reuse_address = True
+            threading.Thread(target=httpd.serve_forever, args=[2], name="webserver").start()
+
+        return httpd
+
+    if not cppm.webserver.local:
+        if not cppm.webserver.valid:
+            econsole.print("[dark_orange3]:warning:[/]  [red italic]Skipping web_server startup[/], [cyan]webserver[/] section missin or invalid.  [dim italic][cyan]base_url[/] is [red]required[/][/dim italic]")
+        else:
+            econsole.print("[yeallow]:information:  [dark_olive_green3 italic]Skipping web_server startup, based on config.[/]")
+        return
+
+    httpd = _start_webserver(port=port)
+    if "--serve-only" in sys.argv:
+        try:
+            econsole.print(":information:  webserver only mode.  CTRL-C to stop webserver")
+            while True:
+                import time
+                time.sleep(3)
+        except (KeyboardInterrupt, EOFError):
+            log.info("Stopping WebServer")
+            httpd.shutdown()
+            sys.exit(0)
+
+    return httpd
+
+
+def _get_update_certs() -> Dict[str, Certificate]:
+    server_version = _get_server_version()
+    svc_map = {
+        "https_rsa": "HTTPS" if server_version.minor < 10 else "HTTPS(RSA)",
+        "https_ecc": "HTTPS(ECC)",
+        "radius": "RADIUS",
+        "radsec": "RadSec"
+    }
+
+    flags = [f"--{k.replace('_', '-')}" for k in svc_map.keys()]
+    push_list = [svc for flag, svc in zip(flags, svc_map.keys()) if flag in sys.argv] or list(svc_map.keys())
+
+    return {svc_map.get(k, k): v for k, v in cppm.certificates.items() if k in push_list}
+
+
+def get_expiry_from_response(rdict: Dict[str, str]) -> pendulum.DateTime:
+    this_exp = rdict["expiry_date"]  # looks like 'Apr 04, 2025 14:04:11 CDT'
+    tzstr = " ".join(this_exp.split()[-1:])  # zz format specifier doesn't work so need to split tz out.  See https://github.com/python-pendulum/pendulum/issues/279
+    tzstr = _get_timezone_from_abbr(tzstr)
+    this_exp = pendulum.from_format(" ".join(this_exp.split()[0:-1]), "MMM DD, YYYY HH:mm:ss", tz=tzstr)
+
+    return this_exp.in_timezone("UTC")
+
+class ClearPassURL:
+    def __init__(self, name: str, url: str | URL, *, cert_p12: str, cert_passphrase: str):
+        self.name: str = name
+        self.url: URL = url if isinstance(url, URL) else URL(url)
+        self.cert_p12 = cert_p12.lstrip("/")
+        self.cert_passphrase = cert_passphrase
+        self.svc = self.url.name
+
+    @property
+    def payload(self)-> Dict[str, str]:
+        return {
+            "pkcs12_file_url": f"{cppm.webserver.url}/{self.cert_p12}",
+            "pkcs12_passphrase": self.cert_passphrase,
+        }
+
+
+
+    def __iter__(self):
+        return iter((self.cert_p12, self.cert_passphrase))
+
+def put_certs() -> List[Tuple[str, Service, UpdateRes]]:
+    """Update Certificates on CPPM nodes"""
+
+    servers = _get_server_ids()
+    certs = _get_update_certs()
+
+    req_data: List[ClearPassURL] = []
+    for svc in certs:
+        cert_p12 = certs[svc].p12
+        cert_passphrase = certs[svc].passphrase
+        req_data += [ClearPassURL(svr, url=f"https://{cppm.fqdn}/api/server-cert/name/{uuid}/{svc}", cert_p12=cert_p12, cert_passphrase=cert_passphrase) for svr, uuid in servers.items()]
+
+    _res = []
+    for req in req_data:
+        try:
+            r = requests.get(req.url, headers=cppm.headers)
+            if r.ok:
+                rdict: Dict[str, str | int | List[str], Dict[str, Any] | bool] = r.json()
+                this_exp = get_expiry_from_response(rdict)
+                le_exp = get_cert_expiration(*req, webserver_url=cppm.webserver.url)
+                diff = le_exp - this_exp
+                is_self_signed = True if rdict.get("subject", "subject") == rdict.get("issued_by", "") else False
+                if diff.days > 0 or is_self_signed:
+                    if is_self_signed:
+                        log.info(f"[bright_green]Updating[/] [dark_olive_green3]{req.name}[/] [cyan]{req.svc}[/] certificate as the current cert is self signed.")
+
+                    # tell cppm to download new cert
+                    r = requests.put(req.url, json=req.payload, headers=cppm.headers, verify=False)
+                    _res.append((req.name, req.svc, "updated") if r.status_code == 200 else (req.name, "error"))
+                    if r.ok:
+                        log.info(f"PUT:OK:{req.name}:{r.status_code}:{r.reason}")
+                    else:
+                        _msg = "\n".join([f"\t{k}: {v}" for k, v in r.json().items() if v])
+                        log.error(f"PUT:ERROR:{req.name}\n{_msg}")
+                else:
+                    _msg = f"LE cert has same expiration as {req.name} {req.svc} cert No Update performed"
+                    _res.append((req.name, req.svc, "same"))
+                    log.info(_msg)
+            else:
+                _res.append((req.name, req.svc, "error"))
+                _msg = f"GET: {r.status_code}:{r.reason}"
+                log.error(_msg)
+        except Exception as e:
+            _msg = f"[red]Exception[/]: [dim italic]({e.__class__.__name__}, {e})[/] in [cyan]put_certs[/]: During Attempt to update [magenta]{req.name}[/] [cyan]{req.svc}[/] certificate @ URL [cyan]{req.url}[/] with new certificate @ {cppm.webserver.url / req.cert_p12}"
+            log.error(_msg, show=True)
+            log.exception(e, show=False)
+
+    return _res
+
+class Version:
+    def __init__(self, version: str):
+        self.major, self.minor, self.patch, self.build = map(int, version.split("."))
+
+    def __str__(self):
+        return ".".join([self.major, self.minor, self.patch, self.build])
+
+
+def _get_server_version() -> Version:
+    """Get server version"""
+
+    url = f"https://{cppm.fqdn}/api/server/version"
+
+    try:
+        r = requests.get(url, headers=cppm.headers)
+        r.raise_for_status()
+    except Exception as e:
+        log.error(f"exception: {e}")
+        exit(1)
+
+    try:
+        return Version(r.json().get("cppm_version"))
+    except Exception as e:
+        print(f"{e.__class__.__class__}, {e}")
+        log.error(e)
+        exit(1)
+
+
+def _load_pb():
+    if cppm.notify and cppm.notify.key:
         try:
             from common.notify import Push
         except ImportError:
@@ -106,241 +311,42 @@ def load_pb():
             log.error("\t Likely Need to 'venv/bin/python3 -m pip install pushbullet.py'")
             return
 
-        return Push(pb_key).sendpush
+        return Push(cppm.notify.key).sendpush
 
 
-def verify_config():
-    values = [cert_p12, cert_passphrase, cppm_config.get("webserver", {}).get("base_url")]
-    keys = ["https_cert_p12", "https_cert_passphrase", "webserver:base_url"]
-    if None in values:
-        missing = [k for k, v in zip(keys, values) if v is None]
-        log.fatal(f"config is missing a required fields ({', '.join(missing)}), please see the example config")
-        exit(1)
-    elif NOTIFY and pb_key and not NOTIFY.get("service"):
-        log.info("No 'service' specified for notifications, assuming PushBullet")
-
-
-def get_le_cert_from_external(webserver_full_url: str):
-    try:
-        r = requests.get(webserver_full_url)
-        if not r.ok:
-            print(f"Failed to get cert from external webserver {webserver_full_url}")
-            sys.exit(1)
-        else:
-            return r.content
-    except Exception as e:
-        log.exception(f"Exception occured while getting current LE cert from {webserver_full_url}. {e.__class__.__name__}", show=True)
-        log.exception(e)
-        sys.exit(1)
-
-
-def verify_cert(this_is_server: bool = True, webserver_full_url: str = None):
-    p = Path(PurePath(cert_dir or Path().home(), cert_p12))
-    if p.exists():
-        pb = p.read_bytes()
-    elif not this_is_server:
-        pb = get_le_cert_from_external(webserver_full_url)
-    else:
-        log.fatal(f"{p.name} Not Found")
-        sys.exit(1)
-
-    le_p12 = pkcs12.load_key_and_certificates(pb, cert_passphrase.encode("UTF-8"), backend=default_backend())
-    le_cert = le_p12[1]
-    le_exp = le_cert.not_valid_after_utc
-
-    return le_exp
-
-
-def get_server_ids(clearpass_fqdn: str, token_type: str, access_token: str) -> list:
-    """Get list of server ids"""
-
-    url = "https://" + clearpass_fqdn + "/api/cluster/server"
-
-    headers = {"Content-Type": "application/json", "Authorization": "{} {}".format(token_type, access_token)}
-
-    try:
-        r = requests.get(url, headers=headers)
-        r.raise_for_status()
-    except Exception as e:
-        log.error(f"exception: {e}")
-        exit(1)
-
-    servers = r.json().get("_embedded", {}).get("items", {})
-    return {svr.get("name"): svr.get("server_uuid") for svr in servers}
-
-
-def start_webserver(port: int = 8080):
-    httpd = None
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    if s.connect_ex(("127.0.0.1", port)) == 0:
-        log.warning(f"Something Appears to be Using port {port}")
-    else:
-        log.info(f"Starting WebServer on Port {port}")
-        handler = CpHandler
-        handler.CERTNAME = cert_p12
-        handler.passphrase = cert_passphrase
-        httpd = HTTPServer(("", port), CpHandler)
-        httpd.allow_reuse_address = True
-        threading.Thread(target=httpd.serve_forever, args=[2], name="webserver").start()
-
-    return httpd
-
-
-def put_https_cert(
-    webserver_url: str,
-    servers: dict,
-    le_exp: datetime.datetime,
-    cppm_fqdn: str,
-    token_type: str,
-    access_token: str,
-    server_version: float,
-) -> list:
-    """Update https Certificate to CPPM"""
-
-    svc = "HTTPS" if int(server_version[1]) < 10 else "HTTPS(RSA)"
-    if "--usage" in sys.argv:
+def do_push(res):
+    if "no-push" not in str(sys.argv):
+        push = _load_pb()
         try:
-            override_svc = sys.argv[sys.argv.index("--usage") + 1]
-        except IndexError:
-            econsole = Console(stderr=True)
-            econsole.print("[red]Error[/]:  Missing argument after [cyan]--usage[/] :triangular_flag:")
-            sys.exit(1)
-    else:
-        override_svc = cppm_config.get("cert_usage") or env.get("CPPM_CERT_USAGE")
-
-    svc = override_svc or svc
-    urls = [(svr, f"https://{cppm_fqdn}/api/server-cert/name/{uuid}/{svc}") for svr, uuid in servers.items()]
-
-    payload = {
-        "pkcs12_file_url": webserver_url,
-        "pkcs12_passphrase": cert_passphrase,
-    }
-
-    headers = {"Content-Type": "application/json", "Authorization": f"{token_type} {access_token}"}
-
-    _res = []
-    for url in urls:
-        try:
-            r = requests.get(url[1], headers=headers)
-            if r.ok:
-                rdict = r.json()
-                this_exp = rdict.get("expiry_date")  # looks like 'Apr 04, 2025 14:04:11 CDT'
-                tzstr = " ".join(this_exp.split()[-1:])  # zz format specifier doesn't work so need to split tz out.  See https://github.com/python-pendulum/pendulum/issues/279
-                tzstr = get_timezone_from_abbr(tzstr)
-                this_exp = pendulum.from_format(" ".join(this_exp.split()[0:-1]), "MMM DD, YYYY HH:mm:ss", tz=tzstr)
-                this_exp = this_exp.in_timezone("UTC")  # covert to UTC to match tz of le_exp
-                diff = le_exp - this_exp
-                is_self_signed = True if rdict.get("subject", "subject") == rdict.get("issued_by", "") else False
-                if diff.days > 0 or is_self_signed:
-                    if is_self_signed:
-                        log.info(f"Updating {url[0]} certificate as the current cert is self signed.")
-
-                    # tell cppm to download new cert
-                    r = requests.put(url[1], json=payload, headers=headers, verify=False)
-                    _res.append((url[0], "updated") if r.status_code == 200 else (url[0], "error"))
-                    if r.ok:
-                        log.info(f"PUT:OK:{url[0]}:{r.status_code}:{r.reason}")
-                    else:
-                        _msg = "\n".join([f"\t{k}: {v}" for k, v in r.json().items() if v])
-                        log.error(f"PUT:ERROR:{url[0]}\n{_msg}")
-                else:
-                    _msg = f"LE cert has same expiration as {url[0]} {svc} cert No Update performed"
-                    _res.append((url[0], "same"))
-                    log.info(_msg)
-            else:
-                _res.append((url[0], "error"))
-                _msg = f"GET: {r.status_code}:{r.reason}"
-                log.error(_msg)
+            if push and [r[2] for r in res if r[2] != "same"]:
+                res_str = "\n".join([f"{svr} ({svc}): {result}" for svr, svc, result in res])
+                push_res = push("ClearPass Cert Update", res_str)
+                log.debug(f"Push Response:\n{push_res}")
         except Exception as e:
-            _msg = "Exception: \n{}".format("\n".join([f"\t{k}: {v}" for k, v in e.__dict__.items()]))
-            log.exception(_msg)
-
-    return _res
-
-
-def get_server_version(clearpass_fqdn: str, token_type: str, access_token: str) -> list:
-    """Get server version"""
-
-    url = "https://" + clearpass_fqdn + "/api/server/version"
-
-    headers = {"Content-Type": "application/json", "Authorization": "{} {}".format(token_type, access_token)}
-
-    try:
-        r = requests.get(url, headers=headers)
-        r.raise_for_status()
-    except Exception as e:
-        log.error(f"exception: {e}")
-        exit(1)
-
-    try:
-        return r.json().get("cppm_version").split(".")[0:2]
-    except Exception as e:
-        print(e)
-        log.error(e)
-        exit(1)
-
-
-def get_webserver_info() -> Tuple[URL, int]:
-    webserver_config = cppm_config.get("webserver", {})
-    webserver_base = webserver_config.get("base_url")
-    webserver_port = webserver_config.get("port", 8080)
-    webserver_path = webserver_config.get("path", "")
-
-    webserver_port = int(webserver_port)
-    port_str = "" if not webserver_port else f":{webserver_port}"
-    full_url = URL(f"{webserver_base}{port_str}/{webserver_path}/{cert_p12}".replace(f"//{cert_p12}", f"/{cert_p12}"))
-
-    return full_url, webserver_port
+            log.exception(f"PushBullet Exception: {e}")
 
 
 if __name__ == "__main__":
-    httpd = None
-    c = Console()
-    # config and file verification
-    verify_config()
+    # TODO make part of cpcli can handle flags there
+    if not cppm.valid_cert_sync:
+        econsole.print(f"[dark_orange3]:warning:[/]  Configuration file {cppm.file} does not appear to be valid.  Refer to example @ https://raw.githubusercontent.com/Pack3tL0ss/clearpass-api-scripts/refs/heads/main/config.yaml.example")
+        exit(1)
 
-    # get server uuids from publisher
-    cluster_servers = get_server_ids(*cppm_args)
+    port = None
+    if "--port" in sys.argv:
+        try:
+            port = int(sys.argv[sys.argv.index["--port" + 1]])
+        except IndexError:
+            econsole.print("[dark_orange3]:warning:[/]  Missing argument after [cyan]--port[/] :triangular_flag:")
+            exit(1)
+        except ValueError:
+            econsole.print(f"[dark_orange3]:warning:[/]  Invalid argument after? [cyan]--port[/] :triangular_flag: {sys.argv[sys.argv.index["--port" + 1]]} should be a valid integer.")
+            exit(1)
 
-    webserver_full_url, webserver_port = get_webserver_info()
-    this_is_server = _this_is_server(webserver_full_url)
-
-    # Start webserver to provide certs to CPPM
-    if this_is_server:
-        httpd = start_webserver(port=webserver_port)
-        if "--serve-only" in sys.argv:
-            try:
-                c.print(":information:  webserver only mode.  CTRL-C to stop webserver")
-                while True:
-                    import time
-                    time.sleep(3)
-            except KeyboardInterrupt:
-                log.info("Stopping WebServer")
-                httpd.shutdown()
-                sys.exit(0)
-    else:
-        if cppm_config.get("webserver", {}).get("local") is None:
-            c.print(f"[dark_orange]:warning:[/] webserver [cyan]{webserver_full_url}[/] defined in config does not appear to be this system.")
-        c.print("skipping web_server startup, based on config.")
-
-    le_exp = verify_cert(this_is_server, webserver_full_url=str(webserver_full_url))
-
-    # get server version
-    cppm_ver = get_server_version(*cppm_args)
-
-    # push certs
-    res = put_https_cert(str(webserver_full_url), cluster_servers, le_exp, *cppm_args, server_version=cppm_ver)
-
+    httpd = start_webserver(port)
+    res = put_certs()
     if httpd:
         log.info("Stopping WebServer")
         httpd.shutdown()
 
-    if "no-push" not in str(sys.argv):
-        try:
-            push = load_pb()
-            if push and [r[1] for r in res if r[1] != "same"]:
-                res_str = "\n".join([f"{svr}: {result}" for svr, result in res])
-                push_res = push("ClearPass https Cert Update", res_str)
-                log.debug(f"Push Response:\n{push_res}")
-        except Exception as e:
-            log.exception(f"PushBullet Exception: {e}")
+    do_push(res)

--- a/cppm-certsync.py
+++ b/cppm-certsync.py
@@ -68,6 +68,7 @@ class CpHandler(BaseHTTPRequestHandler):
         cls.passphrase = passphrase
 
     def do_GET(self):
+        install(show_locals=True)  # better Traceback hook
         self.send_response(200)
         self.send_header("Content-Type", "application/x-pkcs12")
         self.end_headers()
@@ -117,7 +118,7 @@ def get_cert_expiration(cert_p12: str, cert_passphrase: str, webserver_url: URL 
         _msg = f"[red]Exception[/]: [dim italic]({e.__class__.__name__}, {e})[/] in [cyan]get_cert_expiration[/]: During Attempt to get expiration from PKCS12 data.  Host: [magenta]{full_url.host}[/] Certificate: [cyan]{cert_p12}[/]."
         if pb and "</html>" in str(pb):
             _msg += f"  Response appears to be html not a PKCS12 certificate.  Perhaps the path ({full_url.path}) or port ({full_url.port}) is wrong."
-        _msg += "[red italic]Script will exit[/]."
+        _msg += "  [red italic]Script will exit[/]."
         log.error(_msg, show=True)
         log.exception(e, show=False)
         exit(1)

--- a/cppm-certsync.py
+++ b/cppm-certsync.py
@@ -340,7 +340,7 @@ if __name__ == "__main__":
             econsole.print("[dark_orange3]:warning:[/]  Missing argument after [cyan]--port[/] :triangular_flag:")
             exit(1)
         except ValueError:
-            econsole.print(f"[dark_orange3]:warning:[/]  Invalid argument after? [cyan]--port[/] :triangular_flag: {sys.argv[sys.argv.index["--port" + 1]]} should be a valid integer.")
+            econsole.print(f"[dark_orange3]:warning:[/]  Invalid argument after? [cyan]--port[/] :triangular_flag: {sys.argv[sys.argv.index['--port' + 1]]} should be a valid integer.")
             exit(1)
 
     httpd = start_webserver(port)

--- a/cppm-certsync.py
+++ b/cppm-certsync.py
@@ -2,7 +2,7 @@
 #
 # Author: Wade Wells github/Pack3tL0ss
 #
-# Version: 2025-10.0
+# Version: 2025-10.1
 #
 from __future__ import annotations
 
@@ -223,11 +223,14 @@ class ClearPassURL:
     def __iter__(self):
         return iter((self.cert_p12, self.cert_passphrase))
 
-def put_certs() -> List[Tuple[str, Service, UpdateRes]]:
+def put_certs() -> List[Tuple[str, Service, UpdateRes]] | None:
     """Update Certificates on CPPM nodes"""
 
     servers = _get_server_ids()
     certs = _get_update_certs()
+    if not certs:
+        log.warning("No Certificates configured matching provided usage flags.", log=False)
+        return
 
     req_data: List[ClearPassURL] = []
     for svc in certs:
@@ -382,5 +385,7 @@ if __name__ == "__main__":
         log.info("[red]:stop_sign:[/]  Stopping WebServer")
         httpd.shutdown()
 
-    if args.push:
+    if not res:
+        exit(1)
+    elif args.push:
         do_push(res)

--- a/cppm-certsync.py
+++ b/cppm-certsync.py
@@ -361,7 +361,7 @@ def process_args() -> Args:
         except IndexError:
             utils.exit("Missing argument after [cyan]--port[/] :triangular_flag:")
         except ValueError:
-            utils.exit(f"Invalid argument after? [cyan]--port[/] :triangular_flag: {sys.argv[sys.argv.index("--port") + 1]} should be a valid integer.")
+            utils.exit(f"Invalid argument after? [cyan]--port[/] :triangular_flag: {sys.argv[sys.argv.index('--port') + 1]} should be a valid integer.")
     serve_only = True if "--serve-only" in sys.argv else False
     push = False if "--no-push" in sys.argv else True
     if "--debug" in sys.argv:

--- a/cppm-certsync.py
+++ b/cppm-certsync.py
@@ -78,7 +78,7 @@ def get_le_cert_from_external(webserver_full_url: str):
     try:
         r = requests.get(webserver_full_url)
         if not r.ok:
-            econsole.print(f"[dark_orange3]:warning:[/]  Failed to get cert from external webserver {webserver_full_url}")
+            econsole.print(f"[dark_orange3]:warning:[/]  Failed to get cert from external webserver {webserver_full_url} [dim]{r.status_code}[/] [red]{r.reason}[/]")
             exit(1)
         else:
             return r.content
@@ -158,13 +158,13 @@ def start_webserver(port: int = None) -> HTTPServer | None:
         if not cppm.webserver.valid:
             econsole.print("[dark_orange3]:warning:[/]  [red italic]Skipping web_server startup[/], [cyan]webserver[/] section missin or invalid.  [dim italic][cyan]base_url[/] is [red]required[/][/dim italic]")
         else:
-            econsole.print("[yeallow]:information:  [dark_olive_green3 italic]Skipping web_server startup, based on config.[/]")
+            econsole.print("[yeallow]:information:[/]  [dark_olive_green3 italic]Skipping web_server startup, based on config.[/]")
         return
 
     httpd = _start_webserver(port=port)
     if "--serve-only" in sys.argv:
         try:
-            econsole.print(":information:  webserver only mode.  CTRL-C to stop webserver")
+            econsole.print("[yeallow]:information:[/]  webserver only mode.  Use [cyan]CTRL-C[/] to stop webserver")
             while True:
                 import time
                 time.sleep(3)

--- a/cppm-certsync.py
+++ b/cppm-certsync.py
@@ -13,7 +13,6 @@ import threading
 import zoneinfo
 from functools import lru_cache
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from http import HTTPStatus
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Tuple
 
@@ -64,13 +63,13 @@ class CpHandler(BaseHTTPRequestHandler):
         p = cppm.webserver.web_root / self.path.split("/")[-1]
         if p.exists():
             log.info(f"Sending {p.name} to {self.address_string()}")
-            self.send_response(HTTPStatus.OK)
+            self.send_response(200)
             self.send_header("Content-Type", "application/x-pkcs12")
             self.end_headers()
             self.wfile.write(p.read_bytes())
         else:
             log.error(f"Unable to fulfill request from [cyan]{self.address_string()}[/] for [cyan]{p.name}[/].  [cyan]{p}[/] [red]File Not Found[/].")
-            self.send_error(HTTPStatus.NOT_FOUND)
+            self.send_error(404)
         return
 
 

--- a/cppm-certsync.py
+++ b/cppm-certsync.py
@@ -11,12 +11,11 @@ import socket
 import sys
 import threading
 import zoneinfo
+from functools import lru_cache
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
-from typing import Any, Dict, List, TYPE_CHECKING, Literal, Tuple
-from functools import lru_cache
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Tuple
 
-# import netifaces
 import pendulum
 import requests
 from cryptography.hazmat.backends import default_backend
@@ -26,10 +25,12 @@ from yarl import URL
 
 from common import log
 from common.cppmauth import ClearPassAuth
+
 if TYPE_CHECKING:
     from common.config import Certificate
 
 from rich.traceback import install
+
 install(show_locals=True)
 
 UpdateRes = Literal["updated", "same", "older", "error"]

--- a/cppm-certsync.py
+++ b/cppm-certsync.py
@@ -2,7 +2,7 @@
 #
 # Author: Wade Wells github/Pack3tL0ss
 #
-# Version: 2025-9.4
+# Version: 2025-10.0
 #
 from __future__ import annotations
 

--- a/cppmcli/__init__.py
+++ b/cppmcli/__init__.py
@@ -40,8 +40,8 @@ else:
         print("Warning Logic Error in git/pypi detection")
         print(f"base_dir Parts: {base_dir.parts}")
 
-from .logger import MyLogger
-from .config import Config
+from .logger import MyLogger  #NoQA
+from .config import Config  # NoQA
 config = Config(base_dir=base_dir)
 
 log_dir = config.base_dir / "logs"
@@ -63,9 +63,9 @@ log = MyLogger(log_file, debug=config.debug, show=config.debug, verbose=config.d
 log.debug(f"{__name__} __init__ calling script: {_calling_script}, base_dir: {config.base_dir}")
 log.debugv(f"config attributes: {json.dumps({k: str(v) for k, v in config.__dict__.items()}, indent=4)}")
 
-from .utils import Utils
+from .utils import Utils  # NoQA
 utils = Utils()
-from .clicommon import CLICommon
+from .clicommon import CLICommon  #NoQA
 
 if os.environ.get("TERM_PROGRAM") == "vscode":
     from .vscodeargs import vscode_arg_handler

--- a/cppmcli/api_identities.py
+++ b/cppmcli/api_identities.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 from .response import Session
 
-from typing import Dict, Any
+from typing import Dict, Any, List, TypedDict
 from pyclearpass.common import (
     _generate_parameterised_url,
     _remove_empty_keys,
     ClearPassAPILogin,
 )
 
+class Devices(TypedDict):
+    _embedded: Dict[str, List[Dict[str, str | int | dict]]]
+    _links: Dict[str, Dict[str, str]]
 
 class ApiIdentities(Session):
 
@@ -248,7 +251,7 @@ class ApiIdentities(Session):
         Required Path Parameter Name: user_id, Description: User ID of the deny listed user
         Required Path Parameter Name: mac_address, Description: MAC address of the deny listed user
         """
-        url_path = "/deny-listed-users/user_id/{user_id}/mac_address/{mac_address}"
+        url_path = f"/deny-listed-users/user_id/{user_id}/mac_address/{mac_address}"
         dict_path = {"user_id": user_id, "mac_address": mac_address}
         for item in dict_path:
             url_path = url_path.replace("{" + item + "}", dict_path[item])
@@ -257,7 +260,7 @@ class ApiIdentities(Session):
     # Function Section Name:Device
     # Function Section Description: Manage device accounts
 
-    def get_device(self, filter="", sort="", offset="", limit="", calculate_count=""):
+    def get_devices(self, filter="", sort="", offset="", limit="", calculate_count="") -> Devices | str:
         """
         Operation: Get a list of device accounts
         HTTP Status Response Codes: 200 OK, 401 Unauthorized, 403 Forbidden, 406 Not Acceptable, 415 Unsupported Media Type, 422 Unprocessable Entity, 200 OK, 401 Unauthorized, 403 Forbidden, 406 Not Acceptable, 415 Unsupported Media Type, 422 Unprocessable Entity

--- a/cppmcli/api_identities.py
+++ b/cppmcli/api_identities.py
@@ -1,5 +1,8 @@
-from .response import Response, Session
+from __future__ import annotations
 
+from .response import Session
+
+from typing import Dict, Any
 from pyclearpass.common import (
     _generate_parameterised_url,
     _remove_empty_keys,
@@ -31,7 +34,7 @@ class ApiIdentities(Session):
         }
         return await self.get(url, params=params)
 
-    def new_api_client(self, body=({})):
+    def new_api_client(self, body=({})) -> ClearPassAPILogin:
         """
                 Operation: Create a new API client
                 HTTP Status Response Codes: 201 Created, 400 Client Error, 401 Unauthorized, 403 Forbidden, 406 Not Acceptable, 415 Unsupported Media Type, 422 Unprocessable Entity, 201 Created, 400 Client Error, 401 Unauthorized, 403 Forbidden, 406 Not Acceptable, 415 Unsupported Media Type, 422 Unprocessable Entity
@@ -67,7 +70,7 @@ class ApiIdentities(Session):
             self, url=url_path, method="post", query=body
         )
 
-    def get_api_client_by_client_id(self, client_id=""):
+    def get_api_client_by_client_id(self, client_id="") -> Dict[str, Any] | str:
         """
         Operation: Get an API client
         HTTP Status Response Codes: 200 OK, 401 Unauthorized, 403 Forbidden, 404 Not Found, 406 Not Acceptable, 415 Unsupported Media Type, 200 OK, 401 Unauthorized, 403 Forbidden, 404 Not Found, 406 Not Acceptable, 415 Unsupported Media Type

--- a/cppmcli/cli.py
+++ b/cppmcli/cli.py
@@ -3,21 +3,17 @@
 
 import os
 import sys
-import asyncio
 from pathlib import Path
-
-from rich import print
-from rich.console import Console
 
 import typer
 
 try:
-    from cppmcli import cli, config, log, clishow
-except (ImportError, ModuleNotFoundError) as e:
+    from cppmcli import cli, config, log, clishow, clisync
+except (ImportError, ModuleNotFoundError):
     pkg_dir = Path(__file__).absolute().parent
     if pkg_dir.name == "cppmcli" and str(pkg_dir.parent) not in sys.argv:
         sys.path.insert(0, str(pkg_dir.parent))
-    from cppmcli import cli, config, log, clishow
+    from cppmcli import cli, config, log, clishow, clisync
 
 
 CONTEXT_SETTINGS = {
@@ -27,6 +23,7 @@ CONTEXT_SETTINGS = {
 
 app = typer.Typer(context_settings=CONTEXT_SETTINGS, rich_markup_mode="rich")
 app.add_typer(clishow.app, name="show",)
+app.add_typer(clisync.app, name="sync", hidden=True)  # TODO need to move and refactor cppm-certsync to integrate into cli
 
 
 def all_commands_callback(ctx: typer.Context, update_cache: bool):

--- a/cppmcli/clicommon.py
+++ b/cppmcli/clicommon.py
@@ -219,8 +219,8 @@ class CLICommon:
                             if d[sort_by] is not None:
                                 type_ = type(d[sort_by])
                                 break
-                        data = sorted(data, key=lambda d: d[sort_by] if d[sort_by] != "-" else 0 or 0 if type_ == int else "")
-                        # data = sorted(data, key=get_sort(d[sort_by], type_=type_))
+                        data = sorted(data, key=lambda d: d[sort_by] if d[sort_by] != "-" else 0 or 0 if type_ is int else "")
+
                     except TypeError as e:
                         print(
                             f":x: [dark_orange3]Warning:[reset] Unable to sort by [cyan]{sort_by}.\n   {e.__class__.__name__}: {e} "
@@ -251,17 +251,6 @@ class CLICommon:
                 )
 
             typer.echo_via_pager(outdata) if pager and tty and len(outdata) > tty.rows else typer.echo(outdata)
-
-            # TODO test speed of use normal console object.
-            # rich pager may render faster, but need to modify render.output .. rich_output
-            # if pager and tty and len(outdata) > tty.rows:
-            #     with console.pager():
-            #         console.print(outdata)
-            # else:
-            #     console.print(outdata)
-
-            if "Limit:" not in outdata and caption is not None and cleaner and cleaner.__name__ != "parse_caas_response":
-                print(caption)
 
             if outfile and outdata:
                 self.write_file(outfile, outdata.file)

--- a/cppmcli/clisync.py
+++ b/cppmcli/clisync.py
@@ -11,12 +11,12 @@ from rich import print
 
 # Detect if called from pypi installed package or via cloned github repo (development)
 try:
-    from cppmcli import cli, cleaner
+    from cppmcli import cli, cleaner  # NoQA
 except (ImportError, ModuleNotFoundError) as e:
     pkg_dir = Path(__file__).absolute().parent
     if pkg_dir.name == "centralcli":
         sys.path.insert(0, str(pkg_dir.parent))
-        from cppmcli import cli, cleaner
+        from cppmcli import cli, cleaner  # NoQA
     else:
         print(pkg_dir.parts)
         raise e

--- a/cppmcli/clisync.py
+++ b/cppmcli/clisync.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+import typer
+import sys
+from pathlib import Path
+from rich import print
+
+
+# Detect if called from pypi installed package or via cloned github repo (development)
+try:
+    from cppmcli import cli, cleaner
+except (ImportError, ModuleNotFoundError) as e:
+    pkg_dir = Path(__file__).absolute().parent
+    if pkg_dir.name == "centralcli":
+        sys.path.insert(0, str(pkg_dir.parent))
+        from cppmcli import cli, cleaner
+    else:
+        print(pkg_dir.parts)
+        raise e
+
+sys.path.insert(0, Path(__file__).absolute().parent.parent)
+# import cppm_certsync as certsync
+
+app = typer.Typer()
+
+@app.command()
+def certs(
+    port: int = typer.Option(None, help="Override the port used to reach the webserver containing the certificates"),
+):
+    """Sync certificates from local directory (webserver will start locally) or external webserver containing LetsEncrypt or the like certificates.
+    """
+    ...
+
+
+@app.callback()
+def callback():
+    """
+    Sync Certificates
+    """
+    pass
+
+
+if __name__ == "__main__":
+    app()

--- a/cppmcli/render.py
+++ b/cppmcli/render.py
@@ -25,7 +25,7 @@ from rich.text import Text
 # Detect if called from pypi installed package or via cloned github repo (development)
 try:
     from cppmcli import log, utils
-except (ImportError, ModuleNotFoundError) as e:
+except (ImportError, ModuleNotFoundError):
     pkg_dir = Path(__file__).absolute().parent
     if pkg_dir.name == "cppmcli" and str(pkg_dir.parent) not in sys.path:
         sys.path.insert(0, str(pkg_dir.parent))
@@ -240,8 +240,6 @@ def rich_output(
         tuple: raw_data, table_data
     """
     console = Console(record=True, emoji=False)
-
-    customer_id, customer_name = "", ""
 
     # -- // List[dict, ...] \\ --
     if outdata and all(isinstance(x, dict) for x in outdata):

--- a/cppmcli/response.py
+++ b/cppmcli/response.py
@@ -356,7 +356,6 @@ class Session():
         self.server = f"https://{self.auth.server}/api"
         self.verify_ssl = self.auth.verify_ssl
         self.headers = {**DEFAULT_HEADERS, "Authorization": f"Bearer {auth.api_token}"}
-        # self.headers["authorization"] = f"Bearer {auth.central_info['token']['access_token']}"
         self.ssl = auth.verify_ssl
         self.req_cnt = 1
         self.requests: List[LoggedRequests] = []
@@ -389,7 +388,7 @@ class Session():
 
     async def exec_api_call(self, url: str, data: dict = None, json_data: Union[dict, list] = None,
                             method: str = "GET", headers: dict = {}, params: dict = {}, **kwargs) -> Response:
-        auth = self.auth
+        # auth = self.auth
         resp = None
         _url = URL(url).with_query(params)
         _data_msg = ' ' if not url else f' [{_url.path}]'


### PR DESCRIPTION
*Major Overhaul*
 - ♻️Major refactor
 - ✨Add ability to update any certificate type. or multiple types.
 - 🔧Update config file schema (old format still works)
 - 🚩Add support for `--port <webserver port>` on command line to override what's in config
 - 🚩Add support for `--debug` on command line
 - 🚩Add optional `--https-rsa`, `--https-ecc`, `--radius`, and `--radsec` flags.  By default all cert types defined in the config will be updated, these flags can be used to limit a run to specific types.
 - 🚩Added `--serve-only` flag to only start the webserver, which remains running until `CTRL-C`.   _primarily useful for testing_
 - 🚩Added `--help` or `?` flags to show available flags (extracted from section in README)
 - 🔊 Improvements to logging/messaging and error handling.